### PR TITLE
Default html

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -1,5 +1,9 @@
 package controllers
 
+import java.util.Date
+
+import model.{Commenter, Viewpoint, Subject}
+import org.joda.time.DateTime
 import play.api.Logger
 import play.api.mvc.{Action, Controller}
 
@@ -33,7 +37,32 @@ object App extends Controller with PanDomainAuthActions {
   }
 
   def defaultRenderTemp = AuthAction {
-    Ok(views.html.Application.defaultRendering())
+
+    val hillaryClinton = Commenter(1, "Hillary Clinton", Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/12/1452598832111/HillaryClintonR.png"), Some("Former secretary of state"), Some("Democrats"), Some("category?"))
+
+    val donaldTrump = Commenter(2, "Donald Trump", Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/12/1452598831853/DonaldTrumpL.png"), Some("Real estate mogul"), Some("Republicans"), Some("category?"))
+
+    val testCandidates = List(hillaryClinton, donaldTrump)
+
+    val testViewpointOne = Viewpoint(
+      123,
+      1,
+      "What is wrong with us, that we cannot stand up to the NRA and the gun lobby, and the gun manufacturers they represent?",
+      Some("http://www.theguardian.com"),
+      Some(new DateTime(2016, 1, 10, 0, 0))
+    )
+
+    val testViewpointTwo = Viewpoint(
+      123,
+      2,
+      "Here’s another important way to fight crime – empower law-abiding gun owners to defend themselves.",
+      Some("http://www.theguardian.com"),
+      Some(new DateTime(2016, 1, 10, 0, 0))
+    )
+
+    val testSubject = Subject(123, "Gun laws", Some("http://www.theguardian.com"), List(testViewpointOne, testViewpointTwo), 1)
+
+    Ok(views.html.Application.defaultRendering(testSubject, testCandidates))
   }
 
 }

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -32,4 +32,8 @@ object App extends Controller with PanDomainAuthActions {
     Ok(views.html.Application.hello("Hello world"))
   }
 
+  def defaultRenderTemp = AuthAction {
+    Ok(views.html.Application.defaultRendering())
+  }
+
 }

--- a/app/views/Application/defaultRendering.scala.html
+++ b/app/views/Application/defaultRendering.scala.html
@@ -4,6 +4,12 @@
 
 <style>
 
+    /**
+        These styles are provided as reference only and should NOT be included in the eventual atom response.
+
+         - Chris Finch
+    */
+
     body {
         background-color: #ececec;
     }

--- a/app/views/Application/defaultRendering.scala.html
+++ b/app/views/Application/defaultRendering.scala.html
@@ -1,0 +1,151 @@
+<style>
+
+    body {
+        background-color: #ececec;
+    }
+
+    * {
+        box-sizing: border-box;
+    }
+
+    .viewpoints-atom {
+        width: 450px;
+        background-color: #fff;
+        overflow: hidden;
+    }
+
+        .viewpoints-atom__header {
+            width: 100%;
+            padding-left: 24px;
+        }
+
+        .viewpoints-atom__tagline {
+            background-color: #D60A23;
+            color: #fff;
+            width: 55%;
+            padding: 0 2px;
+            margin: 0;
+            font-size: 18px;
+        }
+
+        .viewpoints-atom__viewpoint-title {
+            color: #0C4474;
+            margin: 0;
+            font-size: 28px;
+        }
+
+    .viewpoint {
+        position: relative;
+        width: 100%;
+        margin-top: 48px;
+        overflow: hidden;
+    }
+
+        .viewpoint__contents {
+            padding-bottom: 48px;
+            width: 70%;
+            display: inline-block;
+        }
+
+        .viewpoint__quote {
+            font-size: 22px;
+            margin: 0 24px;
+            width: 85%;
+            text-align: left;
+        }
+
+        .viewpoint__quote:before {
+            content: '"';
+        }
+
+        .viewpoint__quote:after {
+            content: '"';
+        }
+
+        .viewpoint__candidate-name {
+            color: #0C4474;
+            display: block;
+            margin: 0 24px 24px;
+            font-size: 22px;
+        }
+
+        .viewpoint__candidate-title {
+            display: block;
+            font-size: 18px;
+        }
+
+        .viewpoint__date {
+            background-color: #D60A23;
+            color: #fff;
+            display: block;
+            width: 100%;
+            line-height: 24px;
+            padding: 0 24px;
+        }
+
+        .viewpoint__candidate-image-container {
+            position: absolute;
+            right: -24px;
+            bottom: 0;
+            width: 60%;
+            border-bottom: 24px solid #D60A23;
+            text-align: right;
+        }
+
+        .viewpoint__candidate-image {
+            display : inline-block;
+        }
+
+    .viewpoint:nth-child(odd) {
+        text-align: right;
+    }
+
+    .viewpoint:nth-child(odd) .viewpoint__candidate-image-container {
+        right: auto;
+        left: -24px;
+        text-align: left;
+    }
+
+    /*.viewpoint:nth-child(odd) .viewpoint__date {*/
+        /*text-align: ;*/
+    /*}*/
+</style>
+
+<article class="viewpoints-atom">
+
+    <header class="viewpoints-atom__header">
+        <h2 class="viewpoints-atom__tagline">The issues</h2>
+        <h1 class="viewpoints-atom__viewpoint-title">Gun laws</h1>
+    </header>
+
+    <section class="viewpoint">
+
+        <div class="viewpoint__contents">
+            <blockquote class="viewpoint__quote">What is wrong with us, that we cannot stand up to the NRA and the gun lobby, and the gun manufacturers they represent?</blockquote>
+            <cite class="viewpoint__candidate-name">Hillary Clinton<span class="viewpoint__candidate-title">Former secretary of state</span></cite>
+
+            <time class="viewpoint__date">10 January 2016</time>
+        </div>
+
+        <aside class="viewpoint__candidate-image-container">
+            <img class="viewpoint__candidate-image" src="http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/12/1452598832111/HillaryClintonR.png" width="240" alt=""/>
+        </aside>
+
+    </section>
+
+    <section class="viewpoint">
+
+        <div class="viewpoint__contents">
+            <blockquote class="viewpoint__quote">Here’s another important way to fight crime – empower law-abiding gun owners to defend themselves.</blockquote>
+            <cite class="viewpoint__candidate-name">Donald Trump<span class="viewpoint__candidate-title">Real estate mogul</span></cite>
+
+            <time class="viewpoint__date">10 January 2016</time>
+        </div>
+
+        <aside class="viewpoint__candidate-image-container">
+            <img class="viewpoint__candidate-image" src="http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/12/1452598831853/DonaldTrumpL.png" width="240" alt=""/>
+        </aside>
+
+    </section>
+
+</article>

--- a/app/views/Application/defaultRendering.scala.html
+++ b/app/views/Application/defaultRendering.scala.html
@@ -1,3 +1,7 @@
+@(subject: model.Subject, commenters: List[model.Commenter])
+
+@import org.joda.time.format.DateTimeFormat
+
 <style>
 
     body {
@@ -96,56 +100,43 @@
             display : inline-block;
         }
 
-    .viewpoint:nth-child(odd) {
-        text-align: right;
-    }
+        .viewpoint:nth-child(odd) {
+            text-align: right;
+        }
 
-    .viewpoint:nth-child(odd) .viewpoint__candidate-image-container {
-        right: auto;
-        left: -24px;
-        text-align: left;
-    }
+        .viewpoint:nth-child(odd) .viewpoint__candidate-image-container {
+            right: auto;
+            left: -24px;
+            text-align: left;
+        }
 
-    /*.viewpoint:nth-child(odd) .viewpoint__date {*/
-        /*text-align: ;*/
-    /*}*/
 </style>
 
 <article class="viewpoints-atom">
 
     <header class="viewpoints-atom__header">
         <h2 class="viewpoints-atom__tagline">The issues</h2>
-        <h1 class="viewpoints-atom__viewpoint-title">Gun laws</h1>
+        <h1 class="viewpoints-atom__viewpoint-title">@subject.name</h1>
     </header>
 
-    <section class="viewpoint">
+    @for((viewpoint, index) <- subject.viewpoints.zipWithIndex) {
+        @defining(commenters.find(c => c.id == viewpoint.commenterId).get) { commenter =>
+            <section class="viewpoint@{ if(index % 2 != 0) " viewpoint--odd" }">
 
-        <div class="viewpoint__contents">
-            <blockquote class="viewpoint__quote">What is wrong with us, that we cannot stand up to the NRA and the gun lobby, and the gun manufacturers they represent?</blockquote>
-            <cite class="viewpoint__candidate-name">Hillary Clinton<span class="viewpoint__candidate-title">Former secretary of state</span></cite>
+                <div class="viewpoint__contents">
+                    <blockquote class="viewpoint__quote">@viewpoint.quote</blockquote>
+                    <cite class="viewpoint__candidate-name">@commenter.name<span class="viewpoint__candidate-title">@commenter.description</span></cite>
 
-            <time class="viewpoint__date">10 January 2016</time>
-        </div>
+                    @defining(DateTimeFormat.forPattern("d MMMM y")) { dateFormatter =>
+                        <time class="viewpoint__date">@dateFormatter.print(viewpoint.date.get)</time>
+                    }
+                </div>
 
-        <aside class="viewpoint__candidate-image-container">
-            <img class="viewpoint__candidate-image" src="http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/12/1452598832111/HillaryClintonR.png" width="240" alt=""/>
-        </aside>
+                <aside class="viewpoint__candidate-image-container">
+                    <img class="viewpoint__candidate-image" src="@commenter.imageUrl" width="240" alt=""/>
+                </aside>
 
-    </section>
-
-    <section class="viewpoint">
-
-        <div class="viewpoint__contents">
-            <blockquote class="viewpoint__quote">Here’s another important way to fight crime – empower law-abiding gun owners to defend themselves.</blockquote>
-            <cite class="viewpoint__candidate-name">Donald Trump<span class="viewpoint__candidate-title">Real estate mogul</span></cite>
-
-            <time class="viewpoint__date">10 January 2016</time>
-        </div>
-
-        <aside class="viewpoint__candidate-image-container">
-            <img class="viewpoint__candidate-image" src="http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/12/1452598831853/DonaldTrumpL.png" width="240" alt=""/>
-        </aside>
-
-    </section>
-
+            </section>
+        }
+    }
 </article>

--- a/conf/routes
+++ b/conf/routes
@@ -3,6 +3,7 @@ GET        /                              controllers.App.index
 GET        /hello                         controllers.App.hello
 GET        /oauthCallback                 controllers.Login.oauthCallback
 GET        /logout                        controllers.Login.logout
+GET        /defaultRender                 controllers.App.defaultRenderTemp
 
 # API
 GET        /api/commenters                controllers.Api.getCommenters


### PR DESCRIPTION
Adds a template and route to display the defaultHtml rendering of a viewpoints atom.

HTML is semantically marked up and provided with **reference only** styles so that you can view it in the browser.

All being well you should simply be able to inject a viewpoint model along with a list of candidates in to the template and get out the defaultHtml string for inclusion in the atom response.

<img width="481" alt="screen shot 2016-01-13 at 16 32 24" src="https://cloud.githubusercontent.com/assets/1170410/12300421/4318032e-ba13-11e5-8b40-fcb74d7e5442.png">
